### PR TITLE
Renaming repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# buoy_msgs
-
-TODO(anyone)
+# mbari_wec_utils
 
 Packages in this repo provide interfaces, API, examples for MBARI Power Buoy.
 

--- a/buoy_api_cpp/QUALITY_DECLARATION.md
+++ b/buoy_api_cpp/QUALITY_DECLARATION.md
@@ -1,6 +1,6 @@
 This document is a declaration of software quality for the `buoy_api_cpp` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
 
-# buoy_msgs Quality Declaration
+# mbari_wec_utils Quality Declaration
 
 The package `buoy_api_cpp` claims to be in the **Quality Level 5** category.
 
@@ -87,7 +87,7 @@ There are no currently copyrighted source files in this package.
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `buoy_api_cpp` has the following runtime ROS dependencies, which are at **Quality Level 5**:
-* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/buoy_msgs/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
+* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/buoy_api_py/QUALITY_DECLARATION.md
+++ b/buoy_api_py/QUALITY_DECLARATION.md
@@ -87,7 +87,7 @@ There are no currently copyrighted source files in this package.
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `buoy_api_py` has the following runtime ROS dependencies, which are at **Quality Level 5**:
-* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/buoy_msgs/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
+* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/buoy_msgs/CMakeLists.txt
+++ b/buoy_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(buoy_msgs)
+project(mbari_wec_utils)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/buoy_msgs/README.md
+++ b/buoy_msgs/README.md
@@ -1,3 +1,3 @@
 # buoy interface packages
 
-`buoy_msgs` is a metapackage that installs all packages to interface with MBARI Power Buoy
+`mbari_wec_utils` is a metapackage that installs all packages to interface with MBARI Power Buoy

--- a/buoy_msgs/package.xml
+++ b/buoy_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>buoy_msgs</name>
+  <name>mbari_wec_utils</name>
   <version>0.0.0</version>
   <description>Meta-package for MBARI Power Buoy messages (telemetry), services (commands), and API</description>
   <maintainer email="anderson@mbari.org">Michael Anderson</maintainer>

--- a/pbcmd/QUALITY_DECLARATION.md
+++ b/pbcmd/QUALITY_DECLARATION.md
@@ -87,7 +87,7 @@ There are no currently copyrighted source files in this package.
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `pbcmd` has the following runtime ROS dependencies, which are at **Quality Level 5**:
-* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/buoy_msgs/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
+* `buoy_interfaces` [QUALITY DECLARATION](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_interfaces/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 


### PR DESCRIPTION
#### Changes:
- `buoy_msgs` in repo context to `mbari_wec_utils`
- renamed the meta package

#### Workflow:
Rename repos on Github -> Merge in https://github.com/osrf/buoy_entrypoint/pull/38 -> Wait for green CI on https://github.com/osrf/buoy_sim/pull/139 -> Merge in this