### PR TITLE
Revert meta-package rename and fix watchdog command

### DIFF
--- a/buoy_api_cpp/include/buoy_api/interface.hpp
+++ b/buoy_api_cpp/include/buoy_api/interface.hpp
@@ -159,7 +159,7 @@ public:
     tf_set_state_machine_client_ =
       this->create_client<buoy_interfaces::srv::TFSetStateMachineCommand>(
       "/tf_set_state_machine_command");
-    tf_watch_dog_client_ =
+    tf_watchdog_client_ =
       this->create_client<buoy_interfaces::srv::TFWatchDogCommand>("/tf_watchdog_command");
     tf_reset_client_ =
       this->create_client<buoy_interfaces::srv::TFResetCommand>("/tf_reset_command");
@@ -208,7 +208,7 @@ public:
     found &= wait_for_service(tf_set_charge_mode_client_, "/tf_set_charge_mode_command");
     found &= wait_for_service(tf_set_curr_lim_client_, "/tf_set_curr_lim_command");
     found &= wait_for_service(tf_set_state_machine_client_, "/tf_set_state_machine_command");
-    found &= wait_for_service(tf_watch_dog_client_, "/tf_watchdog_command");
+    found &= wait_for_service(tf_watchdog_client_, "/tf_watchdog_command");
     found &= wait_for_service(tf_reset_client_, "/tf_reset_command");
 
     if (!found) {
@@ -674,7 +674,7 @@ protected:
   rclcpp::Client<buoy_interfaces::srv::TFSetCurrLimCommand>::SharedPtr tf_set_curr_lim_client_;
   rclcpp::Client<buoy_interfaces::srv::TFSetStateMachineCommand>::SharedPtr
     tf_set_state_machine_client_;
-  rclcpp::Client<buoy_interfaces::srv::TFWatchDogCommand>::SharedPtr tf_watch_dog_client_;
+  rclcpp::Client<buoy_interfaces::srv::TFWatchDogCommand>::SharedPtr tf_watchdog_client_;
   rclcpp::Client<buoy_interfaces::srv::TFResetCommand>::SharedPtr tf_reset_client_;
 
   // generic service callback

--- a/buoy_api_cpp/include/buoy_api/interface.hpp
+++ b/buoy_api_cpp/include/buoy_api/interface.hpp
@@ -160,7 +160,7 @@ public:
       this->create_client<buoy_interfaces::srv::TFSetStateMachineCommand>(
       "/tf_set_state_machine_command");
     tf_watch_dog_client_ =
-      this->create_client<buoy_interfaces::srv::TFWatchDogCommand>("/tf_watch_dog_command");
+      this->create_client<buoy_interfaces::srv::TFWatchDogCommand>("/tf_watchdog_command");
     tf_reset_client_ =
       this->create_client<buoy_interfaces::srv::TFResetCommand>("/tf_reset_command");
 
@@ -208,7 +208,7 @@ public:
     found &= wait_for_service(tf_set_charge_mode_client_, "/tf_set_charge_mode_command");
     found &= wait_for_service(tf_set_curr_lim_client_, "/tf_set_curr_lim_command");
     found &= wait_for_service(tf_set_state_machine_client_, "/tf_set_state_machine_command");
-    found &= wait_for_service(tf_watch_dog_client_, "/tf_watch_dog_command");
+    found &= wait_for_service(tf_watch_dog_client_, "/tf_watchdog_command");
     found &= wait_for_service(tf_reset_client_, "/tf_reset_command");
 
     if (!found) {

--- a/buoy_msgs/CMakeLists.txt
+++ b/buoy_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(mbari_wec_utils)
+project(buoy_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/buoy_msgs/README.md
+++ b/buoy_msgs/README.md
@@ -1,3 +1,3 @@
 # buoy interface packages
 
-`mbari_wec_utils` is a metapackage that installs all packages to interface with MBARI Power Buoy
+`buoy_msgs` is a metapackage that installs all packages to interface with MBARI Power Buoy

--- a/buoy_msgs/package.xml
+++ b/buoy_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>mbari_wec_utils</name>
+  <name>buoy_msgs</name>
   <version>0.0.0</version>
   <description>Meta-package for MBARI Power Buoy messages (telemetry), services (commands), and API</description>
   <maintainer email="anderson@mbari.org">Michael Anderson</maintainer>


### PR DESCRIPTION
Ensured no package rename (for now)
Topic should be `/tf_watchdog_command` and not `/tf_watch_dog_command`