### PR TITLE
add function to set use_sim_time parameter

### DIFF
--- a/buoy_api_cpp/include/buoy_api/interface.hpp
+++ b/buoy_api_cpp/include/buoy_api/interface.hpp
@@ -320,6 +320,15 @@ public:
     }
   }
 
+  // Setup node clock to use sim time from /clock
+  void use_sim_time(bool enable = true)
+  {
+    this->set_parameter(
+      rclcpp::Parameter(
+        "use_sim_time",
+        enable));
+  }
+
   // set publish rate of PC Microcontroller telemetry
   void set_pc_pack_rate(const uint8_t & rate_hz = 50)
   {

--- a/buoy_api_py/buoy_api/interface.py
+++ b/buoy_api_py/buoy_api/interface.py
@@ -228,6 +228,10 @@ class Interface(Node):
                 sub = self.create_subscription(msg_type, topic, cb, 10)
                 self.subs_.append(sub)
 
+    # Setup node clock to use sim time from /clock
+    def use_sim_time(self, enable=True):
+        self.set_parameters([Parameter('use_sim_time', Parameter.Type.BOOL, enable)])
+
     # set publish rate of PC Microcontroller telemetry
     def set_pc_pack_rate_param(self, rate_hz=50.0):
         request = SetParameters.Request()


### PR DESCRIPTION
call `this->use_sim_time()` or `self.use_sim_time()` to set node clock to use /clock from gz sim via ros_gz_bridge