### PR TITLE
Add simple_interp::Interp2d

### DIFF
--- a/simple_interp/CMakeLists.txt
+++ b/simple_interp/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
+ament_find_gtest()
 
 add_library(${PROJECT_NAME} SHARED src/interp1d.cpp src/interp2d.cpp)
 
@@ -30,6 +32,14 @@ install(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest_executable(test_${PROJECT_NAME}
+    tests/test_${PROJECT_NAME}.cpp
+  )
+
+  target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
+
+  ament_add_gtest_test(test_${PROJECT_NAME})
 endif()
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/simple_interp/CMakeLists.txt
+++ b/simple_interp/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
-add_library(${PROJECT_NAME} SHARED src/interp1d.cpp)
+add_library(${PROJECT_NAME} SHARED src/interp1d.cpp src/interp2d.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/simple_interp/include/simple_interp/interp2d.hpp
+++ b/simple_interp/include/simple_interp/interp2d.hpp
@@ -1,0 +1,74 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SIMPLE_INTERP__INTERP2D_HPP_
+#define SIMPLE_INTERP__INTERP2D_HPP_
+
+
+#include <tuple>
+#include <utility>
+#include <vector>
+
+
+namespace simple_interp
+{
+class Interp2d
+{
+public:
+  //                   x       y       z
+  typedef std::tuple<double, double, double> point_t;
+  typedef std::vector<point_t> table_t;
+
+  Interp2d(const std::vector<double> & x,
+           const std::vector<double> & y,
+           const std::vector<double> & z);
+  explicit Interp2d(const table_t & table,
+                    const std::size_t & stride);
+
+  void update(const std::vector<double> & x,
+              const std::vector<double> & y,
+              const std::vector<double> & z);
+
+  static table_t make_table(const std::vector<double> & x,
+                            const std::vector<double> & y,
+                            const std::vector<double> & z);
+
+  // one-shot eval with vector data
+  static double eval(
+    const std::vector<double> & x_table,
+    const std::vector<double> & y_table,
+    const std::vector<double> & z_table,
+    const double & x_eval,
+    const double & y_eval);
+  // one-shot eval with table data
+  static double eval(const table_t & table,
+                     const std::size_t & stride,
+                     const double & x,
+                     const double & y);
+  // operator version of eval with class instance
+  double operator()(const double & x, const double & y) const;
+  // eval with class instance
+  double eval(const double & x, const double & y) const;
+
+private:
+  std::vector<double> x_, y_;
+  table_t table_;
+  mutable std::vector<double>::const_iterator x_latest_upper_edge_;
+  mutable std::vector<double>::const_iterator y_latest_upper_edge_;
+  mutable bool x_latest_bin_initialized_{false};
+  mutable bool y_latest_bin_initialized_{false};
+};
+}  // namespace simple_interp
+
+#endif  // SIMPLE_INTERP__INTERP2D_HPP_

--- a/simple_interp/include/simple_interp/interp2d.hpp
+++ b/simple_interp/include/simple_interp/interp2d.hpp
@@ -30,19 +30,23 @@ public:
   typedef std::tuple<double, double, double> point_t;
   typedef std::vector<point_t> table_t;
 
-  Interp2d(const std::vector<double> & x,
-           const std::vector<double> & y,
-           const std::vector<double> & z);
-  explicit Interp2d(const table_t & table,
-                    const std::size_t & stride);
+  Interp2d(
+    const std::vector<double> & x,
+    const std::vector<double> & y,
+    const std::vector<double> & z);
+  explicit Interp2d(
+    const table_t & table,
+    const std::size_t & stride);
 
-  void update(const std::vector<double> & x,
-              const std::vector<double> & y,
-              const std::vector<double> & z);
+  void update(
+    const std::vector<double> & x,
+    const std::vector<double> & y,
+    const std::vector<double> & z);
 
-  static table_t make_table(const std::vector<double> & x,
-                            const std::vector<double> & y,
-                            const std::vector<double> & z);
+  static table_t make_table(
+    const std::vector<double> & x,
+    const std::vector<double> & y,
+    const std::vector<double> & z);
 
   // one-shot eval with vector data
   static double eval(
@@ -52,10 +56,11 @@ public:
     const double & x_eval,
     const double & y_eval);
   // one-shot eval with table data
-  static double eval(const table_t & table,
-                     const std::size_t & stride,
-                     const double & x,
-                     const double & y);
+  static double eval(
+    const table_t & table,
+    const std::size_t & stride,
+    const double & x,
+    const double & y);
   // operator version of eval with class instance
   double operator()(const double & x, const double & y) const;
   // eval with class instance

--- a/simple_interp/package.xml
+++ b/simple_interp/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/simple_interp/src/interp1d.cpp
+++ b/simple_interp/src/interp1d.cpp
@@ -109,6 +109,8 @@ double Interp1d::eval(const double & x) const
   }
 
   // search for correct bin otherwise shortcut with same bin
+  // modified from:
+  //   https://stackoverflow.com/questions/8933077/finding-which-bin-a-values-fall-into
   if (!x_in_latest_bin) {
     const double dummy_y{0.0};
     table_t::const_iterator citx =

--- a/simple_interp/src/interp1d.cpp
+++ b/simple_interp/src/interp1d.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <simple_interp/interp1d.hpp>
-
 #include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <vector>
 #include <utility>
+
+#include <simple_interp/interp1d.hpp>
 
 
 namespace simple_interp

--- a/simple_interp/src/interp2d.cpp
+++ b/simple_interp/src/interp2d.cpp
@@ -1,0 +1,274 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <simple_interp/interp2d.hpp>
+#include <simple_interp/interp1d.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+
+namespace simple_interp
+{
+Interp2d::Interp2d(const std::vector<double> & x,
+                   const std::vector<double> & y,
+                   const std::vector<double> & z)
+: x_(x),
+  y_(y),
+  table_{Interp2d::make_table(x, y, z)}
+{
+}
+
+Interp2d::Interp2d(const table_t & table, const std::size_t & stride)
+: table_{table}
+{
+  // x.size() == stride
+  x_.reserve(stride);  // column
+  y_.reserve(table.size() / stride);  // row
+  for (std::size_t row = 0U; row < table.size() / stride; ++row) {
+    for (std::size_t col = 0U; col < stride; ++col) {
+      const point_t xyz = table_[col + stride * row];
+      x_.push_back(std::get<0>(xyz));
+      y_.push_back(std::get<1>(xyz));
+    }
+  }
+}
+
+void Interp2d::update(const std::vector<double> & x,
+                      const std::vector<double> & y,
+                      const std::vector<double> & z)
+{
+  x_ = x;
+  y_ = y;
+  table_ = Interp2d::make_table(x, y, z);
+}
+
+Interp2d::table_t Interp2d::make_table(
+  const std::vector<double> & x,
+  const std::vector<double> & y,
+  const std::vector<double> & z)
+{
+  // row-major address into z and table is x_i (column) + x.size() * y_i (row)
+  assert(x.size() * y.size() == z.size() && "x.size() * y.size() != z.size()");
+  table_t table; table.reserve(z.size());
+  auto z_citx = z.cbegin();
+  for (auto row_citx = y.cbegin(); row_citx != y.cend(); ++row_citx) {
+    for (auto col_citx = x.cbegin(); col_citx != x.cend(); ++col_citx) {
+      if (z_citx != z.cend()) {
+        table.push_back(std::make_tuple(*col_citx,  // x
+                                        *row_citx,  // y
+                                        *z_citx));  // z
+      }
+    }
+  }
+  return table;
+}
+
+// static: one-shot eval with vector data
+double Interp2d::eval(
+  const std::vector<double> & x_table,
+  const std::vector<double> & y_table,
+  const std::vector<double> & z_table,
+  const double & x_eval,
+  const double & y_eval)
+{
+  return Interp2d(x_table, y_table, z_table).eval(x_eval, y_eval);
+}
+
+// static: one-shot eval with table data
+double Interp2d::eval(const Interp2d::table_t & table,
+                      const std::size_t & stride,
+                      const double & x,
+                      const double & y)
+{
+  return Interp2d(table, stride).eval(x, y);
+}
+
+// operator version of eval with class instance
+double Interp2d::operator()(const double & x,
+                            const double & y) const
+{
+  return this->eval(x, y);
+}
+
+// eval with class instance
+double Interp2d::eval(const double & x,
+                      const double & y) const
+{
+  // use bounds of data table and short-cut
+  bool x_oob = false;
+  std::size_t x_oob_idx = 0U;
+  if (x <= x_.front()) {
+    x_oob_idx = 0U;
+    x_oob = true;
+  } else if (x >= x_.back()) {
+    x_oob_idx = x_.size() - 1U;
+    x_oob = true;
+  }
+
+  // check if x is in the previous bin +/- 1 and shortcut the search
+  bool x_in_latest_bin{false};
+  if (!x_oob && x_latest_bin_initialized_) {
+    x_in_latest_bin =
+      (*(x_latest_upper_edge_ - 1U) < x) &&
+      (x <= *x_latest_upper_edge_);
+
+    if (!x_in_latest_bin && x_latest_upper_edge_ + 1 != x_.cend()) {
+      // try up one bin
+      x_in_latest_bin =
+        (*x_latest_upper_edge_ < x) &&
+        (x <= *(x_latest_upper_edge_ + 1U));
+      x_latest_upper_edge_ = x_latest_upper_edge_ + 1U;
+    }
+
+    if (!x_in_latest_bin && x_latest_upper_edge_ - 1U != x_.cbegin()) {
+      // now try down one bin
+      x_in_latest_bin =
+        (*(x_latest_upper_edge_ - 2U) < x) &&
+        (x <= *(x_latest_upper_edge_ - 1U));
+      x_latest_upper_edge_ = x_latest_upper_edge_ - 1U;
+    }
+  }
+
+  // search for correct bin otherwise shortcut with same bin
+  // modified from:
+  //   https://stackoverflow.com/questions/8933077/finding-which-bin-a-values-fall-into
+  if (!x_oob && !x_in_latest_bin) {
+    std::vector<double>::const_iterator x_citx =
+      std::lower_bound(
+      x_.cbegin(),
+      x_.cend(),
+      x);
+
+    if (x_citx == x_.end()) {
+      assert(x_citx != x_.end() && "reached end of x without finding a bin");
+      return 0.0;  // shouldn't get here with bounds checking
+    }
+
+    x_latest_upper_edge_ = x_citx;
+    if (!x_latest_bin_initialized_) {
+      x_latest_bin_initialized_ = true;
+    }
+  }
+
+  // use bounds of data table and short-cut
+  bool y_oob = false;
+  std::size_t y_oob_idx = 0U;
+  if (y <= y_.front()) {
+    y_oob_idx = 0U;
+    y_oob = true;
+  } else if (y >= y_.back()) {
+    y_oob_idx = y_.size() - 1U;
+    y_oob = true;
+  }
+
+  // check if y is in the previous bin +/- 1 and shortcut the search
+  bool y_in_latest_bin{false};
+  if (!y_oob && y_latest_bin_initialized_) {
+    y_in_latest_bin =
+      (*(y_latest_upper_edge_ - 1U) < y) &&
+      (y <= *y_latest_upper_edge_);
+
+    if (!y_in_latest_bin && y_latest_upper_edge_ + 1 != y_.cend()) {
+      // try up one bin
+      y_in_latest_bin =
+        (*y_latest_upper_edge_ < y) &&
+        (y <= *(y_latest_upper_edge_ + 1U));
+      y_latest_upper_edge_ = y_latest_upper_edge_ + 1U;
+    }
+
+    if (!y_in_latest_bin && y_latest_upper_edge_ - 1U != y_.cbegin()) {
+      // now try down one bin
+      y_in_latest_bin =
+        (*(y_latest_upper_edge_ - 2U) < y) &&
+        (y <= *(y_latest_upper_edge_ - 1U));
+      y_latest_upper_edge_ = y_latest_upper_edge_ - 1U;
+    }
+  }
+
+  // search for correct bin otherwise shortcut with same bin
+  // modified from:
+  //   https://stackoverflow.com/questions/8933077/finding-which-bin-a-values-fall-into
+  if (!y_oob && !y_in_latest_bin) {
+    std::vector<double>::const_iterator y_citx =
+      std::lower_bound(
+      y_.cbegin(),
+      y_.cend(),
+      y);
+
+    if (y_citx == y_.end()) {
+      assert(y_citx != y_.end() && "reached end of y without finding a bin");
+      return 0.0;  // shouldn't get here with bounds checking
+    }
+
+    y_latest_upper_edge_ = y_citx;
+    if (!y_latest_bin_initialized_) {
+      y_latest_bin_initialized_ = true;
+    }
+  }
+
+  if (!x_oob && !y_oob) {
+    // compute 2D linear interpolation
+    const std::size_t x0_col_idx = (x_latest_upper_edge_ - 1U) - x_.cbegin();
+    const std::size_t x1_col_idx = x_latest_upper_edge_ - x_.cbegin();
+    const std::size_t y0_row_idx = (y_latest_upper_edge_ - 1U) - y_.cbegin();
+    const std::size_t y1_row_idx = y_latest_upper_edge_ - y_.cbegin();
+    const double & x0 = x_[x0_col_idx];
+    const double & x1 = x_[x1_col_idx];
+    const double & y0 = y_[y0_row_idx];
+    const double & y1 = y_[y1_row_idx];
+
+    const point_t & pt00 = table_[x0_col_idx + x_.size() * y0_row_idx];
+    const point_t & pt10 = table_[x1_col_idx + x_.size() * y0_row_idx];
+    const point_t & pt01 = table_[x0_col_idx + x_.size() * y1_row_idx];
+    const point_t & pt11 = table_[x1_col_idx + x_.size() * y1_row_idx];
+
+    const double & z00 = std::get<2>(pt00);
+    const double & z10 = std::get<2>(pt10);
+    const double & z01 = std::get<2>(pt01);
+    const double & z11 = std::get<2>(pt11);
+
+    const double xx = (x - x0) / (x1 - x0);
+    const double yy = (y - y0) / (y1 - y0);
+
+    return z00 * ( 1 - xx ) * ( 1 - yy ) +
+           z10 * xx * ( 1 - yy ) +
+           z01 * ( 1 - xx ) * yy +
+           z11 * xx * yy;
+  } else if (x_oob && !y_oob) {
+    // compute 1D linear interpolation along y since x is on edge
+    std::size_t y_row_idx = 0U;
+    std::vector<double> z; z.reserve(y_.size());
+    for (; y_row_idx < y_.size(); ++y_row_idx) {
+      z.push_back(std::get<2>(table_[x_oob_idx + x_.size() * y_row_idx]));
+    }
+    return Interp1d::eval(y_, z, y);
+  } else if (!x_oob && y_oob) {
+    // compute 1D linear interpolation along x since y is on edge
+    std::size_t x_row_idx = 0U;
+    std::vector<double> z; z.reserve(x_.size());
+    for (; x_row_idx < x_.size(); ++x_row_idx) {
+      z.push_back(std::get<2>(table_[x_row_idx + x_.size() * y_oob_idx]));
+    }
+    return Interp1d::eval(x_, z, x);
+  } else {
+    // both x and y are on edge, so just return z
+    return std::get<2>(table_[x_oob_idx + x_.size() * y_oob_idx]);
+  }
+}
+}  // namespace simple_interp

--- a/simple_interp/src/interp2d.cpp
+++ b/simple_interp/src/interp2d.cpp
@@ -230,7 +230,8 @@ double Interp2d::eval(
   }
 
   if (!x_oob && !y_oob) {
-    // compute 2D linear interpolation
+    // compute 2D linear interpolation using
+    // `repeated linear interpolation` method of bilinear interpolation
     const std::size_t x0_col_idx = (x_latest_upper_edge_ - 1U) - x_.cbegin();
     const std::size_t x1_col_idx = x_latest_upper_edge_ - x_.cbegin();
     const std::size_t y0_row_idx = (y_latest_upper_edge_ - 1U) - y_.cbegin();
@@ -250,6 +251,7 @@ double Interp2d::eval(
     const double & z01 = std::get<2>(Q01);
     const double & z11 = std::get<2>(Q11);
 
+    // repeated linear interpolation method
     const double xx0 = (x - x0) / (x1 - x0);
     const double xx1 = (x1 - x) / (x1 - x0);
     const double fxy0 = xx1 * z00 + xx0 * z10;

--- a/simple_interp/tests/test_simple_interp.cpp
+++ b/simple_interp/tests/test_simple_interp.cpp
@@ -1,0 +1,108 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <simple_interp/interp1d.hpp>
+#include <simple_interp/interp2d.hpp>
+
+
+// NOLINTNEXTLINE
+class SimpleInterp1dTest : public ::testing::Test
+{
+public:
+  const std::vector<double> x;
+  const std::vector<double> y;
+  simple_interp::Interp1d interp1d;
+
+  SimpleInterp1dTest()
+  : x{0.0, 1.0, 2.0},
+    y{-1.0, 0.0, 1.0},
+    interp1d(x, y)
+  {
+  }
+};
+
+
+TEST_F(SimpleInterp1dTest, Interp1d)
+{
+  EXPECT_EQ(-1.0, interp1d(0.0));
+  EXPECT_EQ(-1.0, interp1d(-1.0));  // x oob to the left
+
+  EXPECT_EQ(-0.5, interp1d(0.5));
+
+  EXPECT_EQ(0.0, interp1d(1.0));
+
+  EXPECT_EQ(0.5, interp1d(1.5));
+
+  EXPECT_EQ(1.0, interp1d(2.0));
+  EXPECT_EQ(1.0, interp1d(3.0));  // x oob to the right
+}
+
+
+// NOLINTNEXTLINE
+class SimpleInterp2dTest : public ::testing::Test
+{
+public:
+  const std::vector<double> x;
+  const std::vector<double> y;
+  const std::vector<double> z;
+  simple_interp::Interp2d interp2d;
+
+  SimpleInterp2dTest()
+  : x{0.0, 1.0, 2.0},
+    y{-1.0, 0.0, 1.0},
+    z{-4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0},
+    interp2d(x, y, z)
+  {
+  }
+};
+
+
+TEST_F(SimpleInterp2dTest, Interp2d)
+{
+  EXPECT_EQ(-4.0, interp2d(-1.0, -1.0));  // x oob to the left
+  EXPECT_EQ(-4.0, interp2d(0.0, -2.0));  // y oob to the left
+  EXPECT_EQ(-4.0, interp2d(-1.0, -2.0));  // x,y oob to the left
+  EXPECT_EQ(-4.0, interp2d(0.0, -1.0));
+  EXPECT_EQ(-3.0, interp2d(1.0, -1.0));
+  EXPECT_EQ(-2.0, interp2d(2.0, -1.0));
+  EXPECT_EQ(-2.0, interp2d(3.0, -1.0));  // x oob to the right
+  EXPECT_EQ(-2.0, interp2d(2.0, -2.0));  // y oob to the left
+  EXPECT_EQ(-2.0, interp2d(3.0, -2.0));  // x,y oob to the right,left
+
+  EXPECT_EQ(-1.0, interp2d(-1.0, 0.0));  // x oob to the left
+  EXPECT_EQ(-1.0, interp2d(0.0, 0.0));
+  EXPECT_EQ(0.0, interp2d(1.0, 0.0));
+  EXPECT_EQ(1.0, interp2d(2.0, 0.0));
+  EXPECT_EQ(1.0, interp2d(3.0, 0.0));  // x oob to the right
+
+  EXPECT_EQ(2.0, interp2d(-1.0, 1.0));  // x oob to the left
+  EXPECT_EQ(2.0, interp2d(0.0, 2.0));  // y oob to the right
+  EXPECT_EQ(2.0, interp2d(-1.0, 2.0));  // x oob to the left,right
+  EXPECT_EQ(2.0, interp2d(0.0, 1.0));
+  EXPECT_EQ(3.0, interp2d(1.0, 1.0));
+  EXPECT_EQ(4.0, interp2d(2.0, 1.0));
+  EXPECT_EQ(4.0, interp2d(3.0, 1.0));  // x oob to the right
+  EXPECT_EQ(4.0, interp2d(2.0, 2.0));  // y oob to the right
+  EXPECT_EQ(4.0, interp2d(3.0, 2.0));  // x,y oob to the right
+
+  EXPECT_EQ(-2.0, interp2d(0.5, -0.5));
+  EXPECT_EQ(-2.5, interp2d(0.0, -0.5));
+  EXPECT_EQ(-2.5, interp2d(-1.0, -0.5));  // x oob and reduces to z = interp1d(y)
+  EXPECT_EQ(-3.5, interp2d(0.5, -1.0));
+  EXPECT_EQ(-3.5, interp2d(0.5, -2.0));  // y oob and reduces to z = interp1d(z)
+}

--- a/simple_interp/tests/test_simple_interp.cpp
+++ b/simple_interp/tests/test_simple_interp.cpp
@@ -104,5 +104,5 @@ TEST_F(SimpleInterp2dTest, Interp2d)
   EXPECT_EQ(-2.5, interp2d(0.0, -0.5));
   EXPECT_EQ(-2.5, interp2d(-1.0, -0.5));  // x oob and reduces to z = interp1d(y)
   EXPECT_EQ(-3.5, interp2d(0.5, -1.0));
-  EXPECT_EQ(-3.5, interp2d(0.5, -2.0));  // y oob and reduces to z = interp1d(z)
+  EXPECT_EQ(-3.5, interp2d(0.5, -2.0));  // y oob and reduces to z = interp1d(x)
 }


### PR DESCRIPTION
added 2D interpolation as well as unit tests

Input to Interp2d is two `std::vector<double>` x, y as well as a `std::vector<double>` z which is a flat array assuming row-major stride such that:
x.size() == stride
z.size() == x.size()*y.size()

so indexing into the flat z array becomes:
z_index = x_index + x.size() * y_index;
where y_index == i and x_index == j
and indexing into a z matrix would normally be z[i, j]

e.g.
```
std::vector<double> x{0.0, 1.0, 2.0};
std::vector<double> y{-1.0, -0.0, -1.0};
std::vector<double> z{-4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0};
simple_interp::Interp2d interp2d(x, y, z);
...
double new_z = interp2d(0.5, -0.5);  // results in new_z = -2.0
```
```
i   y         z
2   1  |   2  3  4
1   0  |  -1  0  1
0  -1  |  -4 -3 -2
        ----------
          0  1  2  x
          0  1  2  j
```